### PR TITLE
Update runtime

### DIFF
--- a/com.gitlab.kendellfab.restscope.json
+++ b/com.gitlab.kendellfab.restscope.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.gitlab.kendellfab.restscope",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.dmd"


### PR DESCRIPTION
This would be good to have as GNOME 3.36 is EOL.

I'm not sure if the buttons in the headerbar are supposed to render like this though : 
![image](https://user-images.githubusercontent.com/39467792/123490503-31d06c00-d5e2-11eb-93d1-f384d055731b.png)
