### PR TITLE
Mark Rest Scope as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64"],
+    "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
I have marked this project as EOL, because there is no org.freedesktop.Sdk.Extension.dmd for modern runtimes.